### PR TITLE
Add zip method to customize filename into zip file

### DIFF
--- a/core/src/main/scala/better/files/Cmds.scala
+++ b/core/src/main/scala/better/files/Cmds.scala
@@ -124,4 +124,13 @@ object Cmds {
     } output.add(file, name.toString)
     destination
   }
+
+  def zip(files: (File, String)*)(destination: File, compressionLevel: Int)(implicit codec: Codec, d: DummyImplicit): File = {
+    for {
+      output <- new ZipOutputStream(destination.newOutputStream, codec).withCompressionLevel(compressionLevel).autoClosed
+      input <- files
+      file <- input._1.walk()
+    } output.add(file, input._2)
+    destination
+  }
 }


### PR DESCRIPTION
J'ai crée une nouvelle method zip dans les commands proposé par better-files qui permet de zipper des fichiers en modifiant leur filename dans le zip.

L'idée étant de proposer une PR dans la librairie officiel de better-files, voici ce qu'il faudrait faire pour avoir une PR propre: 

Todo:
- [ ] Valider le choix technique
- [ ] Rajouter un/des tests
- [ ] Mettre à jour le README
- [ ] Rédiger le texte de la PR en anglais
